### PR TITLE
Fix BMI grid shape definition

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,7 +4,7 @@ Changes for bmi-geotiff
 0.2.2 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Fix shapes in BMI (#6)
 
 
 0.2.1 (2021-05-05)

--- a/bmi_geotiff/bmi.py
+++ b/bmi_geotiff/bmi.py
@@ -359,7 +359,7 @@ class BmiGeoTiff(Bmi):
         ndarray of float
             The input numpy array that holds the grid's layer z-coordinates.
         """
-        if grid == 0:
+        if grid == 0 and self._da.ndim > 2:
             z[:] = self._da.band.values
         else:
             z[:] = 0
@@ -691,11 +691,7 @@ class BmiGeoTiff(Bmi):
 
         self._grid = {
             0: BmiGridRectilinear(
-                shape=(
-                    self._da.sizes["band"],
-                    self._da.sizes["y"],
-                    self._da.sizes["x"],
-                ),
+                shape=tuple(self._da.sizes.values()),
                 type="rectilinear",
             ),
             1: BmiGridNone(


### PR DESCRIPTION
This PR fixes a minor problem of my own creation in #5; namely, the `band` attribute is no longer available for data with dimensions < 3, and it was used to define the grid shape in the BMI.