### PR TITLE
Change metadata for string exchange item

### DIFF
--- a/bmi_geotiff/bmi.py
+++ b/bmi_geotiff/bmi.py
@@ -714,9 +714,9 @@ class BmiGeoTiff(Bmi):
                 grid=0,
             ),
             self._output_var_names[1]: BmiVar(
-                dtype="<U1",
-                itemsize=1,
-                nbytes=len(self._da.attrs["crs"]),
+                dtype="U{}".format(len(self._da.attrs["crs"])),
+                itemsize=len(self._da.attrs["crs"]) * SIZEOF_FLOAT,
+                nbytes=len(self._da.attrs["crs"]) * SIZEOF_FLOAT,
                 location="none",
                 units="1",
                 grid=1,


### PR DESCRIPTION
This PR changes the way the "gis__coordinate_reference_system" exchange item, a 16-character scalar string, is handled. Previously, I had set the *type* and *itemsize* to 1, and *nbytes* to 16. This passed the bmi-tester, but it resulted in a 16-element array of single-character strings. Now, I've set the *type* to 16-character unsigned, and set *itemsize* = *nbytes* to be multiples of this type. This results in a 16-character scalar string.  
