### PR TITLE
Use rasterio GitHub org for links

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ Start a Python session and import the `GeoTiff` class:
 For convenience,
 let's use a test image from the [rasterio](https://rasterio.readthedocs.io) project: 
 ```python
->>> url = "https://github.com/mapbox/rasterio/raw/master/tests/data/RGB.byte.tif"
+>>> url = "https://github.com/rasterio/rasterio/raw/master/tests/data/RGB.byte.tif"
 ```
 
 Make an instance of `GeoTiff` with this URL:

--- a/docs/source/README.rst
+++ b/docs/source/README.rst
@@ -71,7 +71,7 @@ For convenience, let’s use a test image from the
 
 .. code:: python
 
-   >>> url = "https://github.com/mapbox/rasterio/raw/master/tests/data/RGB.byte.tif"
+   >>> url = "https://github.com/rasterio/rasterio/raw/master/tests/data/RGB.byte.tif"
 
 Make an instance of ``GeoTiff`` with this URL:
 

--- a/examples/geotiff.ipynb
+++ b/examples/geotiff.ipynb
@@ -99,7 +99,7 @@
    "metadata": {},
    "source": [
     "The `GeoTiff` class operates on local files. (It doesn't fetch them from the internet.)\n",
-    "Here, we'll use the test file [RGB.byte.tif](https://github.com/mapbox/rasterio/raw/master/tests/data/RGB.byte.tif) from the rasterio project.\n",
+    "Here, we'll use the test file [RGB.byte.tif](https://github.com/rasterio/rasterio/raw/master/tests/data/RGB.byte.tif) from the rasterio project.\n",
     "It's included in the examples directory of the [bmi-geotiff repository](https://github.com/csdms/bmi-geotiff),\n",
     "but if you don't have it locally, click the link above to download it.\n",
     "\n",


### PR DESCRIPTION
The *rasterio* project was recently transferred from the *mapbox* GitHub organization to a new *rasterio* organization. This PR updates a few links to reflect this change.