### PR TITLE
Switch from xarray to rioxarray

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -58,7 +58,7 @@ pretty: ## reformat files to make them look pretty
 	find bmi_geotiff tests examples docs -name '*.py' | xargs isort
 	black bmi_geotiff tests examples docs
 
-test: ## run tests quickly with the default Python
+test: install ## run tests quickly with the default Python
 	pytest --disable-warnings --cov=bmi_geotiff --cov-report=xml:./coverage.xml -vvv
 
 bmi-test: ## run the bmi-tester
@@ -68,7 +68,7 @@ coverage: ## check code coverage quickly with the default Python
 	pytest --cov --cov-report=html
 	$(BROWSER) htmlcov/index.html
 
-docs: ## generate Sphinx HTML documentation, including API docs and link check
+docs: install ## generate Sphinx HTML documentation, including API docs and link check
 	rm -f docs/source/api/bmi_geotiff.rst
 	rm -f docs/source/api/modules.rst
 	sphinx-apidoc -o docs/source/api bmi_geotiff

--- a/bmi_geotiff/bmi.py
+++ b/bmi_geotiff/bmi.py
@@ -722,7 +722,7 @@ class BmiGeoTiff(Bmi):
                 grid=1,
             ),
             self._output_var_names[2]: BmiVar(
-                dtype=type(self._da.rio.transform().a),
+                dtype=type(self._da.rio.transform().a).__name__,
                 itemsize=SIZEOF_FLOAT,
                 nbytes=len(self._da.rio.transform()) * SIZEOF_FLOAT,
                 location="none",

--- a/bmi_geotiff/bmi.py
+++ b/bmi_geotiff/bmi.py
@@ -25,8 +25,8 @@ class BmiGeoTiff(Bmi):
     _input_var_names = ()
     _output_var_names = (
         "gis__raster_data",
-        "gis__coordinate_reference_system",
-        "gis__gdal_geotransform",
+        "gis__coordinate_reference_system_well_known_text",
+        "gis__affine_transform",
     )
 
     def __init__(self) -> None:

--- a/bmi_geotiff/io.py
+++ b/bmi_geotiff/io.py
@@ -1,5 +1,5 @@
 """Access GeoTIFF files."""
-import xarray as xr
+import rioxarray
 
 
 class GeoTiff:
@@ -14,8 +14,8 @@ class GeoTiff:
         filename : str, optional
             Path or URL to the file to open.
         """
-        self._da = None
         self._filename = None
+        self._da = None
 
         if filename is not None:
             self.open(filename)
@@ -37,7 +37,7 @@ class GeoTiff:
             Path or URL to the file to open.
         """
         self._filename = filename
-        self._da = xr.open_rasterio(self._filename)
+        self._da = rioxarray.open_rasterio(self._filename)
         try:
             band = self._da.squeeze("band")
         except ValueError:

--- a/bmi_geotiff/io.py
+++ b/bmi_geotiff/io.py
@@ -1,5 +1,6 @@
 """Access GeoTIFF files."""
 import rioxarray
+from rasterio.crs import CRS
 
 
 class GeoTiff:
@@ -44,3 +45,9 @@ class GeoTiff:
             pass
         else:
             self._da = band
+
+        crs = CRS.from_wkt(self._da.spatial_ref.crs_wkt)
+        if crs.is_projected:
+            self._da.attrs["units"] = crs.linear_units
+        else:
+            self._da.attrs["units"] = "degrees"

--- a/environment.yml
+++ b/environment.yml
@@ -7,7 +7,7 @@ dependencies:
   - pip
   - pyyaml
   - rioxarray
-  - rasterio
+  - rasterio >=1.0
   - bmipy
   - make
   - black

--- a/environment.yml
+++ b/environment.yml
@@ -6,7 +6,7 @@ dependencies:
   - python =3
   - pip
   - pyyaml
-  - xarray
+  - rioxarray
   - rasterio
   - bmipy
   - make

--- a/examples/geotiff.ipynb
+++ b/examples/geotiff.ipynb
@@ -223,7 +223,7 @@
     }
    ],
    "source": [
-    "crs = ccrs.UTM('18N')\n",
+    "crs = ccrs.UTM('18', southern_hemisphere=False)\n",
     "ax = plt.subplot(projection=crs)\n",
     "tif.da.plot.imshow(ax=ax, rgb='band', transform=crs)"
    ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,12 +26,11 @@ classifiers = [
 ]
 requires-python = ">=3.7"
 dependencies = [
-  "requests",
   "numpy",
-  "click",
   "pyyaml",
   "xarray",
   "rasterio",
+  "rioxarray",
   "bmipy",
 ]
 dynamic = ["readme", "version"]

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -54,6 +54,7 @@ def test_open(shared_datadir):
     g.open(f)
     assert g.filename == f
     assert isinstance(g.da, DataArray)
+    assert g.da.attrs["units"] is not None
 
 
 def test_squeeze_band():


### PR DESCRIPTION
This PR updates *bmi-geotiff* to use *rioxarray* instead of *xarray*; in particular, it uses the [rio accessor](https://corteva.github.io/rioxarray/stable/rioxarray.html#rioxarray-rio-accessors) and the *spatial_ref* nondimensional coordinate for geopspatial information.

This fixes #11 and #12.