### PR TITLE
Fix source and binary distributions

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,7 @@
+include *.md
+include *.cff
+include environment.yml
+include Makefile
+include examples/*
+recursive-include tests *
+recursive-include docs *

--- a/Makefile
+++ b/Makefile
@@ -82,15 +82,15 @@ setup: ## generate a setup.py file for release tools
 	echo "import setuptools" >> setup.py
 	echo "setuptools.setup()" >> setup.py
 
-build: clean setup ## build and package a release
+dist: clean setup ## build and package a release
 	python -m build
 	ls -l dist
 
-testpypi: build ## upload a release to TestPyPI
+testpypi: dist ## upload a release to TestPyPI
 	twine check dist/*
 	twine upload --repository-url https://test.pypi.org/legacy/ dist/*
 
-pypi: build ## upload a release to PyPI
+pypi: dist ## upload a release to PyPI
 	twine upload --repository-url https://upload.pypi.org/legacy/ dist/*
 
 prerelease: clean setup ## generate a prerelease with zest.releaser

--- a/Makefile
+++ b/Makefile
@@ -85,9 +85,9 @@ setup: ## generate a setup.py file for release tools
 dist: clean setup ## build and package a release
 	python -m build
 	ls -l dist
+	twine check dist/*
 
 testpypi: dist ## upload a release to TestPyPI
-	twine check dist/*
 	twine upload --repository-url https://test.pypi.org/legacy/ dist/*
 
 pypi: dist ## upload a release to PyPI

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -65,10 +65,7 @@ version = {attr = "bmi_geotiff._version.__version__"}
 
 [tool.setuptools.packages.find]
 where = ["."]
-exclude = [
-  "bmi_geotiff.tests*",
-  "bmi_geotiff.examples*",
-]
+include = ["bmi_geotiff*"]
 
 [tool.pytest.ini_options]
 minversion = "6.0"


### PR DESCRIPTION
This PR updates what files go into the source and binary distributions of the *bmi-geotiff* package.