### PR TITLE
Fix docs build

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -3,16 +3,12 @@ version: 2
 build:
   os: ubuntu-22.04
   tools:
-    python: "3.11"
+    python: "mambaforge-22.9"
+
+conda:
+  environment: environment.yml
 
 sphinx:
   builder: html
   configuration: docs/source/conf.py
   fail_on_warning: false
-
-python:
-  install:
-    - requirements: docs/source/requirements.txt
-    - method: pip
-      path: .
-  system_packages: false

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -12,3 +12,8 @@ sphinx:
   builder: html
   configuration: docs/source/conf.py
   fail_on_warning: false
+
+python:
+  install:
+    - method: pip
+      path: .

--- a/environment.yml
+++ b/environment.yml
@@ -3,7 +3,7 @@ name: geotiff
 channels:
   - conda-forge
 dependencies:
-  - python =3
+  - python >=3.9
   - pip
   - pyyaml
   - rioxarray


### PR DESCRIPTION
This PR fixes the failing docs builds on rtfd.io caused by the obsolete `python.system_packages` setting.

I also chose to switch to using conda / mambaforge to install dependencies.