### PR TITLE
Use Miniforge instead of Mambaforge

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -29,7 +29,6 @@ jobs:
 
       - uses: conda-incubator/setup-miniconda@v3
         with:
-          miniforge-variant: Mambaforge
           miniforge-version: latest
           python-version: ${{ matrix.python-version }}
 


### PR DESCRIPTION
Mambaforge is [going away](https://conda-forge.org/news/2024/07/29/sunsetting-mambaforge/) in favor of Miniforge. This PR switches over the CI testing workflow.