### PR TITLE
Fix failing docs build

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,8 +2,9 @@
 
 ## 0.3.4 (unreleased)
 
-
-- Nothing changed yet.
+- Fix failing docs build (#32)
+- Use Miniforge instead of Mambaforge in CI (#31)
+- Make a landing page for the examples (#30)
 
 
 ## 0.3.3 (2024-08-17)

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,3 +1,3 @@
-sphinx
+sphinx >=8
 recommonmark
 pandoc

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -6,17 +6,18 @@
 
 # -- Path setup --------------------------------------------------------------
 
+# import sys
+# sys.path.insert(0, os.path.abspath('.'))
+import datetime
 # If extensions (or modules to document with autodoc) are in another directory,
 # add these directories to sys.path here. If the directory is relative to the
 # documentation root, use os.path.abspath to make it absolute, like shown here.
 #
 import os
-# import sys
-# sys.path.insert(0, os.path.abspath('.'))
-import datetime
-import packaging
 import pathlib
 import re
+
+import packaging
 
 
 def get_version_from_file(path):

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -10,26 +10,45 @@
 # add these directories to sys.path here. If the directory is relative to the
 # documentation root, use os.path.abspath to make it absolute, like shown here.
 #
-# import os
+import os
 # import sys
 # sys.path.insert(0, os.path.abspath('.'))
 import datetime
+import packaging
+import pathlib
+import re
 
-import pkg_resources
+
+def get_version_from_file(path):
+    with open(path) as fp:
+        match = re.search(r'__version__\s*=\s*[\'"]([^\'"]+)[\'"]', fp.read())
+        if match:
+            version = match.group(1)
+        else:
+            raise ValueError(f"version string not found ({path})")
+    return packaging.version.Version(version)
+
+
+src_dir = os.path.abspath(
+    os.path.join(os.path.dirname(__file__), os.pardir, os.pardir, "bmi_geotiff")
+)
+# sys.path.insert(0, src_dir)
+docs_dir = pathlib.Path(__file__).parent
+version_file = os.path.join(src_dir, "_version.py")
 
 # The master toctree document.
 master_doc = "index"
-
 
 # -- Project information -----------------------------------------------------
 
 project = "bmi-geotiff"
 author = "Community Surface Dynamics Modeling System"
-version = pkg_resources.get_distribution("bmi_geotiff").version
-release = version
 this_year = datetime.date.today().year
 copyright = f"{this_year}, {author}"
 
+v = get_version_from_file(version_file)
+version = f"{v.major}.{v.minor}"
+release = v.public
 
 # -- General configuration ---------------------------------------------------
 

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -1,5 +1,9 @@
-# Configuration file for the Sphinx documentation builder.
-#
+""" conf.py
+    Configuration file for the Sphinx documentation builder.
+
+   isort:skip_file
+"""
+
 # This file only contains a selection of the most common options. For a full
 # list see the documentation:
 # https://www.sphinx-doc.org/en/master/usage/configuration.html
@@ -9,6 +13,7 @@
 # import sys
 # sys.path.insert(0, os.path.abspath('.'))
 import datetime
+
 # If extensions (or modules to document with autodoc) are in another directory,
 # add these directories to sys.path here. If the directory is relative to the
 # documentation root, use os.path.abspath to make it absolute, like shown here.

--- a/environment.yml
+++ b/environment.yml
@@ -21,6 +21,6 @@ dependencies:
   - notebook
   - matplotlib
   - cartopy
-  - build
+  - python-build
   - twine
   - zest.releaser

--- a/environment.yml
+++ b/environment.yml
@@ -15,7 +15,7 @@ dependencies:
   - pytest-datadir
   - coveralls
   - bmi-tester
-  - sphinx
+  - sphinx >=8
   - recommonmark
   - pandoc
   - notebook

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,7 +49,7 @@ dev = [
   "nox",
 ]
 build = [
-  "build",
+  "python-build",
   "twine",
   "zest.releaser"
 ]


### PR DESCRIPTION
It turned out to be a simple fix--I made sure to use the renamed *python-build* package instead of the old *build* package. I also worked around the deprecated *pkg_resources* library, getting the package version through a clever technique I lifted from Landlab. 