### PR TITLE
Update CI workflows and project metadata

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -22,7 +22,7 @@ jobs:
       - uses: conda-incubator/setup-miniconda@v3
         with:
           miniforge-version: latest
-          python-version: 3.11
+          python-version: 3.12
           auto-activate-base: false
 
       - name: Install dependencies

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -18,11 +18,9 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - uses: conda-incubator/setup-miniconda@v3
+      - uses: actions/setup-python@v5
         with:
-          miniforge-version: latest
           python-version: 3.11
-          auto-activate-base: false
 
       - name: Install nox
         run: pip install nox

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -20,7 +20,7 @@ jobs:
 
       - uses: actions/setup-python@v5
         with:
-          python-version: 3.11
+          python-version: 3.12
 
       - name: Install nox
         run: pip install nox

--- a/.github/workflows/test-notebooks.yml
+++ b/.github/workflows/test-notebooks.yml
@@ -27,12 +27,9 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - uses: conda-incubator/setup-miniconda@v3
+      - uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
-          miniforge-variant: Miniforge3
-          miniforge-version: latest
-          auto-update-conda: true
 
       - name: Install nox
         run: pip install nox

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -27,6 +27,10 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+
       - uses: conda-incubator/setup-miniconda@v3
         with:
           miniforge-version: latest

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,7 @@
 
 ## 0.3.4 (unreleased)
 
+- Update CI workflows and project metadata (#33)
 - Fix failing docs build (#32)
 - Use Miniforge instead of Mambaforge in CI (#31)
 - Make a landing page for the examples (#30)

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 [![PyPI](https://img.shields.io/pypi/v/bmi-geotiff)](https://pypi.org/project/bmi-geotiff)
 [![Conda Version](https://img.shields.io/conda/vn/conda-forge/bmi-geotiff.svg)](https://anaconda.org/conda-forge/bmi-geotiff)
 [![Test](https://github.com/csdms/bmi-geotiff/actions/workflows/test.yml/badge.svg)](https://github.com/csdms/bmi-geotiff/actions/workflows/test.yml)
-[![Documentation Status](https://readthedocs.org/projects/bmi-geotiff/badge/?version=latest)](https://bmi-geotiff.readthedocs.io/en/latest/?badge=latest)
+[![Documentation Status](https://readthedocs.org/projects/bmi-geotiff/badge/?version=latest)](https://bmi-geotiff.csdms.io/en/latest/?badge=latest)
 
 # bmi-geotiff
 
@@ -15,11 +15,11 @@ Data are loaded into an
 using the [rioxarray](https://corteva.github.io/rioxarray/stable/index.html)
 [open_rasterio](https://corteva.github.io/rioxarray/stable/rioxarray.html#rioxarray.open_rasterio) method.
 The API is wrapped with a
-[Basic Model Interface](https://bmi.readthedocs.io) (BMI),
+[Basic Model Interface](https://bmi.csdms.io) (BMI),
 which provides a standard set of functions for coupling with data or models
 that also expose a BMI.
 More information on the BMI can found in its
-[documentation](https://bmi.readthedocs.io).
+[documentation](https://bmi.csdms.io).
 
 ## Installation
 
@@ -136,4 +136,4 @@ included in the [examples](https://github.com/csdms/bmi-geotiff/tree/main/exampl
 of the *bmi-geotiff* repository.
 
 Documentation for *bmi-geotiff*
-is available at https://bmi-geotiff.readthedocs.io.
+is available at https://bmi-geotiff.csdms.io.

--- a/docs/source/CHANGES.rst
+++ b/docs/source/CHANGES.rst
@@ -4,7 +4,10 @@ Changes for bmi-geotiff
 0.3.4 (unreleased)
 ------------------
 
--  Nothing changed yet.
+-  Update CI workflows and project metadata (#33)
+-  Fix failing docs build (#32)
+-  Use Miniforge instead of Mambaforge in CI (#31)
+-  Make a landing page for the examples (#30)
 
 0.3.3 (2024-08-17)
 ------------------

--- a/docs/source/README.rst
+++ b/docs/source/README.rst
@@ -13,10 +13,10 @@ using the
 `rioxarray <https://corteva.github.io/rioxarray/stable/index.html>`__
 `open_rasterio <https://corteva.github.io/rioxarray/stable/rioxarray.html#rioxarray.open_rasterio>`__
 method. The API is wrapped with a `Basic Model
-Interface <https://bmi.readthedocs.io>`__ (BMI), which provides a
-standard set of functions for coupling with data or models that also
-expose a BMI. More information on the BMI can found in its
-`documentation <https://bmi.readthedocs.io>`__.
+Interface <https://bmi.csdms.io>`__ (BMI), which provides a standard set
+of functions for coupling with data or models that also expose a BMI.
+More information on the BMI can found in its
+`documentation <https://bmi.csdms.io>`__.
 
 Installation
 ------------
@@ -155,7 +155,7 @@ scripts included in the
 directory of the *bmi-geotiff* repository.
 
 Documentation for *bmi-geotiff* is available at
-https://bmi-geotiff.readthedocs.io.
+https://bmi-geotiff.csdms.io.
 
 .. |DOI| image:: https://zenodo.org/badge/DOI/10.5281/zenodo.4721474.svg
    :target: https://doi.org/10.5281/zenodo.4721474
@@ -166,4 +166,4 @@ https://bmi-geotiff.readthedocs.io.
 .. |Test| image:: https://github.com/csdms/bmi-geotiff/actions/workflows/test.yml/badge.svg
    :target: https://github.com/csdms/bmi-geotiff/actions/workflows/test.yml
 .. |Documentation Status| image:: https://readthedocs.org/projects/bmi-geotiff/badge/?version=latest
-   :target: https://bmi-geotiff.readthedocs.io/en/latest/?badge=latest
+   :target: https://bmi-geotiff.csdms.io/en/latest/?badge=latest

--- a/noxfile.py
+++ b/noxfile.py
@@ -33,7 +33,7 @@ def test(session: nox.Session) -> None:
         session.run("coverage", "report", "--ignore-errors", "--show-missing")
 
 
-@nox.session(name="test-bmi", python=PYTHON_VERSIONS, venv_backend="conda")
+@nox.session(name="test-bmi", python=PYTHON_VERSIONS)
 def test_bmi(session: nox.Session) -> None:
     """Test the Basic Model Interface."""
     session.install("bmi-tester>=0.5.9")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,6 +43,7 @@ Homepage = "https://csdms.colorado.edu"
 Documentation = "https://bmi-geotiff.csdms.io/"
 Repository = "https://github.com/csdms/bmi-geotiff"
 Changelog = "https://github.com/csdms/bmi-geotiff/blob/main/CHANGES.md"
+Forum = "https://forum.csdms.io"
 
 [project.optional-dependencies]
 dev = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,3 @@
-[build-system]
-requires = ["setuptools", "wheel"]
-build-backend = "setuptools.build_meta"
-
 [project]
 name = "bmi-geotiff"
 description = "Access data and metadata in a GeoTIFF file through an API or a BMI"
@@ -70,6 +66,10 @@ examples = [
   "cartopy",
   "matplotlib",
 ]
+
+[build-system]
+requires = ["setuptools", "wheel"]
+build-backend = "setuptools.build_meta"
 
 [tool.setuptools.dynamic]
 readme = {file = ["README.md", "CREDITS.md", "LICENSE.md"], content-type = "text/markdown"}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,7 +40,7 @@ dynamic = ["readme", "version"]
 
 [project.urls]
 Homepage = "https://csdms.colorado.edu"
-Documentation = "https://bmi-geotiff.readthedocs.io/"
+Documentation = "https://bmi-geotiff.csdms.io/"
 Repository = "https://github.com/csdms/bmi-geotiff"
 Changelog = "https://github.com/csdms/bmi-geotiff/blob/main/CHANGES.md"
 


### PR DESCRIPTION
This PR contains a set of maintenance updates to the project metadata files and CI workflows.

This includes:
* Switch to *venv* from *conda* for the CI workflows (except for the docs)
* Point to the csdms.io url for docs
* Use Python 3.12 for lint and docs workflows
