### PR TITLE
Update license metadata for PEP 639

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,13 +10,13 @@ keywords = [
   "raster",
   "data",
 ]
-license = {text = "MIT License"}
+license = "MIT"
+license-files = ["LICENSE.md"]
 classifiers = [
   "Programming Language :: Python :: 3",
   "Programming Language :: Python :: 3.12",
   "Programming Language :: Python :: 3.13",
   "Programming Language :: Python :: 3.14",
-  "License :: OSI Approved :: MIT License",
   "Operating System :: OS Independent",
   "Intended Audience :: Developers",
   "Intended Audience :: Science/Research",


### PR DESCRIPTION
This PR updates the license metadata in `pyproject.toml` for [PEP 639](https://peps.python.org/pep-0639/).

I learned about this from https://github.com/landlab/landlab/pull/2344.