### PR TITLE
Review build on Read the Docs

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,9 +1,9 @@
 version: 2
 
 build:
-  os: ubuntu-22.04
+  os: ubuntu-lts-latest
   tools:
-    python: "mambaforge-22.9"
+    python: "miniforge3-latest"
 
 conda:
   environment: environment.yml

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,8 @@
 
 ## 0.3.5 (unreleased)
 
+- Review build on Read the Docs (#39)
+- Convert docs to MyST Markdown (#38)
 - Update license metadata for PEP 639 (#37)
 - Update supported Python version to 3.14 (#36)
 - Update pre-commit hooks (#35)

--- a/environment.yml
+++ b/environment.yml
@@ -16,8 +16,7 @@ dependencies:
   - coveralls
   - bmi-tester
   - sphinx >=8
-  - recommonmark
-  - pandoc
+  - myst_parser
   - notebook
   - matplotlib
   - cartopy

--- a/environment.yml
+++ b/environment.yml
@@ -16,7 +16,7 @@ dependencies:
   - coveralls
   - bmi-tester
   - sphinx >=8
-  - myst_parser
+  - myst-parser
   - notebook
   - matplotlib
   - cartopy


### PR DESCRIPTION
The switch to MyST Markdown caused the docs build on Read the Docs to fail. This PR fixes the error and updates the Read the Docs configuration.